### PR TITLE
Add support for .vpy input files

### DIFF
--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -32,6 +32,7 @@ else:
 parser = argparse.ArgumentParser()
 parser.add_argument("-s", "--stage", help = "Select stage: 1 = encode, 2 = calculate metrics, 3 = generate zones | Default: all", default=0)
 parser.add_argument("-i", "--input", required=True, help = "Video input filepath (original source file)")
+parser.add_argument("-t", "--temp", help = "The temporary directory for av1an to store files in | Default: input file name")
 parser.add_argument("-q", "--quality", help = "Base quality (CRF) | Default: 30", default=30)
 parser.add_argument("-d", "--deviation", help = "Maximum CRF change from original | Default: 10", default=10)
 parser.add_argument("-p", "--preset", help = "Fast encode preset | Default: 9", default=9)
@@ -44,7 +45,8 @@ args = parser.parse_args()
 stage = int(args.stage)
 src_file = Path(args.input).resolve()
 output_dir = src_file.parent
-tmp_dir = output_dir / "temp"
+tmp_dir_name = args.temp if args.temp is not None else src_file.stem
+tmp_dir = output_dir / tmp_dir_name
 output_file = output_dir / f"{src_file.stem}_fastpass.mkv"
 scenes_file = tmp_dir / "scenes.json"
 br = float(args.deviation)

--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -32,7 +32,7 @@ else:
 parser = argparse.ArgumentParser()
 parser.add_argument("-s", "--stage", help = "Select stage: 1 = encode, 2 = calculate metrics, 3 = generate zones | Default: all", default=0)
 parser.add_argument("-i", "--input", required=True, help = "Video input filepath (original source file)")
-parser.add_argument("-t", "--temp", help = "The temporary directory for av1an to store files in | Default: input file name")
+parser.add_argument("-t", "--temp", help = "The temporary directory for av1an to store files in | Default: video input filename")
 parser.add_argument("-q", "--quality", help = "Base quality (CRF) | Default: 30", default=30)
 parser.add_argument("-d", "--deviation", help = "Maximum CRF change from original | Default: 10", default=10)
 parser.add_argument("-p", "--preset", help = "Fast encode preset | Default: 9", default=9)
@@ -45,8 +45,7 @@ args = parser.parse_args()
 stage = int(args.stage)
 src_file = Path(args.input).resolve()
 output_dir = src_file.parent
-tmp_dir_name = args.temp if args.temp is not None else src_file.stem
-tmp_dir = output_dir / tmp_dir_name
+tmp_dir = Path(args.temp).resolve() if args.temp is not None else output_dir / src_file.stem
 output_file = output_dir / f"{src_file.stem}_fastpass.mkv"
 scenes_file = tmp_dir / "scenes.json"
 br = float(args.deviation)

--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -183,7 +183,12 @@ def calculate_ssimu2(src_file, enc_file, ssimu2_txt_path, ranges, skip):
             skip = args.skip if args.skip is not None else '3'
 
     # If ssimu2zig is True or turbo-metrics failed, use vs-zip
-    source_clip = core.lsmas.LWLibavSource(source=src_file, cache=0)
+    is_vpy = os.path.splitext(os.path.basename(src_file))[1] == ".vpy"
+    vpy_vars = {}
+    if is_vpy:
+        exec(open(src_file).read(), globals(), vpy_vars)
+    # in order for auto-boost to use a .vpy file as a source, the output clip should be a global variable named clip
+    source_clip = core.lsmas.LWLibavSource(source=src_file, cache=0) if not is_vpy else vpy_vars["clip"]
     encoded_clip = core.lsmas.LWLibavSource(source=enc_file, cache=0)
 
     #source_clip = source_clip.resize.Bicubic(format=vs.RGBS, matrix_in_s='709').fmtc.transfer(transs="srgb", transd="linear", bits=32)


### PR DESCRIPTION
As long as the input .vpy file has a global variable named "clip", it will be properly evaluated during the SSIMU2 calculation phase.