### PR TITLE
Fix `--stage 2` extra parameter to `calculate_metrics()`

### DIFF
--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -543,7 +543,7 @@ match stage:
     case 2:
         ranges = get_ranges(scenes_file)
         metrics = int(args.metrics)
-        calculate_metrics(src_file, output_file, tmp_dir, ranges, skip, metrics, video_params)
+        calculate_metrics(src_file, output_file, tmp_dir, ranges, skip, metrics)
     case 3:
         ranges = get_ranges(scenes_file)
         zones = int(args.zones)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\path\to\auto-boost_2.5.py", line 553, in <module>
    calculate_metrics(src_file, output_file, tmp_dir, ranges, skip, metrics, video_params)
TypeError: calculate_metrics() takes 6 positional arguments but 7 were given
```