### PR TITLE
Fix `--skip 1` for vs-zip by removing `SelectEvery`

### DIFF
--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -220,8 +220,12 @@ def calculate_ssimu2(src_file, enc_file, ssimu2_txt_path, ranges, skip):
     iter = 0
     with tqdm(total=floor(len(source_clip)), desc=f'Calculating SSIMULACRA 2 scores') as pbar:
         for i in range(len(ranges) - 1):
-            cut_source_clip = source_clip[ranges[i]:ranges[i+1]].std.SelectEvery(cycle=skip, offsets=1)
-            cut_encoded_clip = encoded_clip[ranges[i]:ranges[i+1]].std.SelectEvery(cycle=skip, offsets=1)
+            if skip > 1:
+                cut_source_clip = source_clip[ranges[i]:ranges[i+1]].std.SelectEvery(cycle=skip, offsets=1)
+                cut_encoded_clip = encoded_clip[ranges[i]:ranges[i+1]].std.SelectEvery(cycle=skip, offsets=1)
+            else:
+                cut_source_clip = source_clip[ranges[i]:ranges[i+1]]
+                cut_encoded_clip = encoded_clip[ranges[i]:ranges[i+1]]
             result = core.vszip.Metrics(cut_source_clip, cut_encoded_clip, mode=0)
             for index, frame in enumerate(result.frames()):
                 iter += 1


### PR DESCRIPTION
Sorry for the critics in the Discord. Thank you for developing autoboost. It's very helpful.

That's said:
```
Traceback (most recent call last):
  File "C:\path\to\auto-boost_2.5.py", line 562, in <module>
    calculate_metrics(src_file, output_file, tmp_dir, ranges, skip, metrics)
  File "C:\path\to\auto-boost_2.5.py", line 412, in calculate_metrics
    calculate_ssimu2(src_file, output_file, ssimu2_txt_path, ranges, skip)
  File "C:\path\to\auto-boost_2.5.py", line 226, in calculate_ssimu2
    cut_source_clip = source_clip[ranges[i]:ranges[i+1]].std.SelectEvery(cycle=skip, offsets=1)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "src\\cython\\vapoursynth.pyx", line 3123, in vapoursynth.Function.__call__
vapoursynth.Error: SelectEvery: invalid cycle size (must be greater than 1)
```